### PR TITLE
Add a quick disable method, mirroring the quick enable method

### DIFF
--- a/lib/flipside.rb
+++ b/lib/flipside.rb
@@ -39,6 +39,11 @@ module Flipside
       feature.update(enabled: true)
     end
 
+    def disable!(name)
+      feature = find_by!(name:)
+      feature.update(enabled: false)
+    end
+
     def add_entity(entity:, feature: nil, name: nil)
       feature ||= find_by!(name:)
       Entity.find_or_create_by(feature:, flippable: entity)

--- a/spec/flipside_spec.rb
+++ b/spec/flipside_spec.rb
@@ -122,6 +122,22 @@ module Flipside
       end
     end
 
+    describe ".disable!" do
+      it "disables the feature" do
+        feature = Feature.create!(name: "some_feature", enabled: true)
+
+        Flipside.disable! :some_feature
+
+        expect(feature.reload.enabled).to eq(false)
+      end
+
+      it "raises an exception when feature does not exist" do
+        expect {
+          Flipside.disable! :non_existing
+        }.to raise_error(NoSuchFeauture)
+      end
+    end
+
     describe ".disabled?" do
       it "returns true when feature does not exist" do
         expect(Flipside.disabled?(:non_existing)).to eq(true)


### PR DESCRIPTION
## Description
It bothered me that I could quickly enable a feature but not do the same for quickly disabling one.